### PR TITLE
fix: unblock 0.2.1 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,7 +304,7 @@ jobs:
       - name: Build release binary
         shell: bash
         run: |
-          cargo deb --profile deb --target ${{ env.TARGET }}
+          cargo deb --target ${{ env.TARGET }}
           version="${{ needs.create-release.outputs.version }}"
           echo "DEB_DIR=target/${{ env.TARGET }}/debian" >> $GITHUB_ENV
           echo "DEB_NAME=precursor_$version-1_amd64.deb" >> $GITHUB_ENV

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,7 @@ fn main() {
 
     // Create a clap::ArgMatches object to store the CLI arguments
     let cmd = Command::new("precursor")
+    .version(env!("CARGO_PKG_VERSION"))
     .about("Precursor is a PCRE2 payload tagging and similarity hashing CLI (TLSH/LZJD) for text, binary, hex, or base64 input.")
     .color(ColorChoice::Auto)
     .long_about("Precursor currently supports the following TLSH algorithms:\n

--- a/tests/cli_contract.rs
+++ b/tests/cli_contract.rs
@@ -117,6 +117,13 @@ fn single_packet_emits_protocol_fields() {
 }
 
 #[test]
+fn version_flag_emits_package_version() {
+    let output = run_precursor(&["--version"], "");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
 fn protocol_hints_include_inference_context() {
     let line_one =
         "GET /one HTTP/1.1 Host: example.org User-Agent: precursor-long-test-agent-aaaaaaaaaa";


### PR DESCRIPTION
## Summary\n- remove unsupported `--profile deb` from `cargo deb` release job\n- expose `--version` in the CLI so `help2man` succeeds in release packaging\n- add CLI contract coverage for version output\n\n## Validation\n- cargo fmt --all --check\n- cargo test --workspace\n- cargo run -- --version\n