### PR TITLE
fix: use gnu target for deb packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,7 +274,7 @@ jobs:
     needs: ["create-release"]
     runs-on: ubuntu-latest
     env:
-      TARGET: x86_64-unknown-linux-musl
+      TARGET: x86_64-unknown-linux-gnu
       # Emit backtraces on panics.
       RUST_BACKTRACE: 1
       # Since we're distributing the dpkg, we don't know whether the user will


### PR DESCRIPTION
## Summary\n- build the Debian package from `x86_64-unknown-linux-gnu` instead of musl\n- keeps release archive jobs unchanged while unblocking `build-release-deb`\n\n## Why\n`cargo-deb` packaging in the release workflow is failing with the musl target.\n