### PR TITLE
fix: ensure release matrix targets are installed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
 
+      - name: Ensure target is installed
+        shell: bash
+        run: rustup target add ${{ matrix.target }}
+
       - name: Use Cross
         if: matrix.os == 'ubuntu-latest' && matrix.target != ''
         shell: bash


### PR DESCRIPTION
## Summary\n- explicitly run rustup target add for each release matrix target\n- fixes missing-target failures for macOS x86_64 and win32-msvc jobs\n\n## Context\nRecent release runs failed with E0463 (target may not be installed) despite requesting targets via toolchain action.\n