### PR TITLE
chore(release): cut 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+0.2.2 - 2026-02-14
+===================
+
+## Added
+- New GitHub Pages demo UX:
+  - dark visual theme and improved stakeholder-facing narrative
+  - interactive scenario explorer with command/output/stats/insights tabs
+  - analyst refinement loop visualization driven by captured `--stats` snapshots
+  - codex-guided LLM demo with measured step-4 validation output
+- New site branding assets:
+  - `site/precursor-mark.svg`
+  - `site/favicon.svg`
+  - refreshed README/site logo in `assets/logo/precursor-logo.svg`
+- Demo data provenance docs:
+  - `site/data/README.md`
+
+## Changed
+- README header and project positioning now align with packet/log/binary pre-protocol triage workflows.
+- Pages content now links directly to scenario corpora and captured demo artifacts for reproducibility.
+
+## Notes
+- Local Claude CLI demo output is not bundled in this release snapshot because the local CLI auth state was unauthenticated during capture; runtime status is documented in `site/data/llm_claude_status.json`.
+
 0.2.1 - 2026-02-14
 ===================
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,7 +556,7 @@ checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "precursor"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "atomic-counter",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "precursor"
 build = "build.rs"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.86"
 authors = ["Matt Lehman <obsecurus@users.noreply.github.com>"]


### PR DESCRIPTION
## Summary
- bump crate version from 0.2.1 to 0.2.2
- add 0.2.2 changelog entry for site UX/demo/branding work
- include Cargo.lock root package version update

## Validation
- cargo test --workspace
