### PR TITLE
fix: add crates.io API user-agent in release publish checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,7 +370,10 @@ jobs:
         run: |
           set -euo pipefail
           version="${{ needs.create-release.outputs.version }}"
-          status="$(curl -sS -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/precursor/$version")"
+          status="$(curl -sS -o /dev/null -w "%{http_code}" \
+            -H "User-Agent: precursor-release-ci" \
+            -H "Accept: application/json" \
+            "https://crates.io/api/v1/crates/precursor/$version")"
           if [ "$status" = "200" ]; then
             echo "already_published=true" >> "$GITHUB_OUTPUT"
             echo "precursor $version is already published on crates.io; skipping cargo publish."
@@ -397,7 +400,10 @@ jobs:
           set -euo pipefail
           version="${{ needs.create-release.outputs.version }}"
           for attempt in $(seq 1 18); do
-            status="$(curl -sS -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/precursor/$version")"
+            status="$(curl -sS -o /dev/null -w "%{http_code}" \
+              -H "User-Agent: precursor-release-ci" \
+              -H "Accept: application/json" \
+              "https://crates.io/api/v1/crates/precursor/$version")"
             if [ "$status" = "200" ]; then
               echo "Confirmed precursor $version on crates.io."
               exit 0


### PR DESCRIPTION
## Summary
- add required headers for crates.io API checks in publish workflow
- prevents 403 responses in pre-publish and verify-publish checks

## Why
Release run 22010327953 failed in publish-crates because crates.io rejected header-less API requests.
