### PR TITLE
release: 0.2.3 cargo publish compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+0.2.3 - 2026-02-14
+===================
+
+## Fixed
+- Cargo publish pipeline now succeeds on crates.io category validation:
+  - replaced unsupported category slug `datascience` with `science` in `Cargo.toml`.
+- Release reruns for the same tag are now safe:
+  - `gh release upload` now uses clobber mode in both archive upload jobs.
+- `publish-crates` crates.io API checks now include required request headers to avoid 403 responses.
+
 0.2.2 - 2026-02-14
 ===================
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,7 +556,7 @@ checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "precursor"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "atomic-counter",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "precursor"
 build = "build.rs"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.86"
 authors = ["Matt Lehman <obsecurus@users.noreply.github.com>"]
@@ -12,7 +12,7 @@ description = "Pre-protocol payload tagging, similarity clustering, and packet/f
 readme = "README.md"
 keywords = ["ids", "forensics", "similarity", "packet", "firmware"]
 license = "MIT OR Unlicense"
-categories = ["command-line-utilities", "filesystem", "datascience"]
+categories = ["command-line-utilities", "filesystem", "science"]
 exclude = [
   ".env",
   ".env.*",


### PR DESCRIPTION
## Summary
- bump version to 0.2.3
- replace unsupported crates.io category slug datascience with science
- update changelog with release automation fixes

## Why
0.2.2 release workflow reached publish-crates but crates.io rejected metadata (400 Bad Request) due unsupported category slug.
