### PR TITLE
fix: use crates.io trusted publishing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,6 +353,10 @@ jobs:
     name: publish-crates
     needs: ["create-release", "build-release", "build-release-deb"]
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -385,10 +389,15 @@ jobs:
             exit 1
           fi
 
+      - name: Authenticate to crates.io via trusted publishing
+        if: steps.crates_check.outputs.already_published != 'true'
+        id: crates_auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish to crates.io
         if: steps.crates_check.outputs.already_published != 'true'
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_auth.outputs.token }}
         shell: bash
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Fixed
 - Cargo publish pipeline now succeeds on crates.io category validation:
   - replaced unsupported category slug `datascience` with `science` in `Cargo.toml`.
+- Cargo publish workflow now uses crates.io Trusted Publishing (OIDC) in `release.yml`.
 - Release reruns for the same tag are now safe:
   - `gh release upload` now uses clobber mode in both archive upload jobs.
 - `publish-crates` crates.io API checks now include required request headers to avoid 403 responses.


### PR DESCRIPTION
## Summary
- switch publish-crates to OIDC trusted publishing via rust-lang/crates-io-auth-action
- add required job permissions (id-token write) and release environment
- keep release notes in changelog aligned with release automation changes

## Why
crates.io rejects static token publish for this crate with: New versions can only be published using Trusted Publishing.
